### PR TITLE
Url typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > - I can get a list of the most recently submitted search strings.
 
 ## Example search usage
-`https://ja-urlshortener-ms.glitch.me/api/imagesearch/dresses?offset=10`
+`https://ja-imagesearch-ms.glitch.me/api/imagesearch/dresses?offset=10`
 
 ## Example list hisory usage
-`https://ja-urlshortener-ms.glitch.me/api/latest/imagesearch`
+`https://ja-imagesearch-ms.glitch.me/api/latest/imagesearch`

--- a/views/index.html
+++ b/views/index.html
@@ -19,9 +19,9 @@
       <ul><li>I can get a list of the most recently submitted search strings.</li></ul>
     </blockquote>
     <h3>Example search usage:</h3>
-    <code><a href="https://ja-urlshortener-ms.glitch.me/api/imagesearch/dresses?offset=10">https://ja-urlshortener-ms.glitch.me/api/imagesearch/dresses?offset=10</a></code>
+    <code><a href="https://ja-imagesearch-ms.glitch.me/api/imagesearch/dresses?offset=10">https://ja-imagesearch-ms.glitch.me/api/imagesearch/dresses?offset=10</a></code>
     <h3>Example list history usage:</h3>
-    <code><a href="https://ja-urlshortener-ms.glitch.me/api/latest/imagesearch">https://ja-urlshortener-ms.glitch.me/api/latest/imagesearch</a></code>
+    <code><a href="https://ja-imagesearch-ms.glitch.me/api/latest/imagesearch">https://ja-imagesearch-ms.glitch.me/api/latest/imagesearch</a></code>
   </div>
 </body>
 


### PR DESCRIPTION
Fixes a URL typo. 'url-shortener' gets replaced with 'imagesearch'. Thanks to @zdflower for catching it.  👋 